### PR TITLE
fix: target ES2017 for compatibility with older bundlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-12-23
+
+### Bug fixes
+
+- Fixed compatibility with older bundlers (Vue 2 + babel-loader) by targeting ES2017 instead of ES2020 ([#18](https://github.com/sergical/blockchain-wallet-validator/issues/18))
+
 ## [1.2.0] - 2025-11-11
 
 ### Enhancements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-wallet-validator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A comprehensive blockchain wallet address validator",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/__tests__/build-compatibility.test.ts
+++ b/src/__tests__/build-compatibility.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, test } from 'vitest';
+
+/**
+ * Build compatibility tests to ensure the library works with older bundlers.
+ *
+ * Issue #18: Users with older build setups (Vue 2 + babel-loader) that don't
+ * transpile node_modules were getting parse errors from ES2020+ syntax.
+ *
+ * These tests verify the build output is ES2017 compatible.
+ */
+describe('Build Compatibility', () => {
+  const distPath = join(process.cwd(), 'dist');
+  const cjsPath = join(distPath, 'index.cjs');
+  const mjsPath = join(distPath, 'index.mjs');
+
+  // ES2020+ syntax patterns that should NOT appear in ES2017 output
+  const es2020Patterns = [
+    {
+      name: 'nullish coalescing operator (??)',
+      // Match ?? but not inside strings or comments
+      // This pattern looks for ?? with word chars or brackets around it
+      pattern: /\w\s*\?\?\s*[\w\[\{'"]/,
+    },
+    {
+      name: 'optional chaining (?.)',
+      // Match ?. but not in ternary expressions like a ? .b : c
+      pattern: /\w\?\.[a-zA-Z\[]/,
+    },
+    {
+      name: 'nullish assignment (??=)',
+      pattern: /\?\?=/,
+    },
+    {
+      name: 'logical AND assignment (&&=)',
+      pattern: /&&=/,
+    },
+    {
+      name: 'logical OR assignment (||=)',
+      pattern: /\|\|=/,
+    },
+  ];
+
+  test.runIf(existsSync(cjsPath))(
+    'CJS bundle should not contain ES2020+ syntax',
+    () => {
+      const content = readFileSync(cjsPath, 'utf-8');
+
+      for (const { name, pattern } of es2020Patterns) {
+        const match = content.match(pattern);
+        expect(
+          match,
+          `Found ${name} in CJS bundle at: "${match?.[0]}". ` +
+            `The build should target ES2017 or lower for compatibility with older bundlers.`,
+        ).toBeNull();
+      }
+    },
+  );
+
+  test.runIf(existsSync(mjsPath))(
+    'ESM bundle should not contain ES2020+ syntax',
+    () => {
+      const content = readFileSync(mjsPath, 'utf-8');
+
+      for (const { name, pattern } of es2020Patterns) {
+        const match = content.match(pattern);
+        expect(
+          match,
+          `Found ${name} in ESM bundle at: "${match?.[0]}". ` +
+            `The build should target ES2017 or lower for compatibility with older bundlers.`,
+        ).toBeNull();
+      }
+    },
+  );
+
+  test.runIf(existsSync(cjsPath))('CJS bundle should be parseable', () => {
+    const content = readFileSync(cjsPath, 'utf-8');
+    // Basic check - the file should be valid JavaScript
+    expect(content).toContain('validateWalletAddress');
+    expect(content.length).toBeGreaterThan(1000);
+  });
+
+  test.runIf(existsSync(mjsPath))('ESM bundle should be parseable', () => {
+    const content = readFileSync(mjsPath, 'utf-8');
+    // Basic check - the file should be valid JavaScript
+    expect(content).toContain('validateWalletAddress');
+    expect(content.length).toBeGreaterThan(1000);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: true,
   clean: true,
+  target: 'es2017',
   outExtension({ format }) {
     return {
       js: format === 'cjs' ? '.cjs' : '.mjs',


### PR DESCRIPTION
## Summary
- Set tsup target to ES2017 to transpile ES2020+ syntax (`??`, `?.`)
- Add build compatibility tests to prevent regression

Fixes #18

## Test plan
- [x] All 108 tests pass
- [x] Bundle size within limits (CJS: 12.86KB/13KB, ESM: 6.92KB/7KB)
- [x] Build output verified to not contain ES2020+ syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)