### PR TITLE
ci: use npm trusted publishers (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,5 +35,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove NPM_TOKEN secret, use OIDC trusted publishers instead
- More secure - no long-lived tokens to manage

🤖 Generated with [Claude Code](https://claude.com/claude-code)